### PR TITLE
Update multiqml.py

### DIFF
--- a/multiqml.py
+++ b/multiqml.py
@@ -74,7 +74,7 @@ class MultiQmlDlg(QDialog, Ui_MultiQmlForm):
       line = qmlFile.readline()
       result = False
       while line != "":
-        if "<rasterproperties>" in line:
+        if "<rasterproperties>" in line or "<rasterrenderer" in line:
           result = True
           break
         line = qmlFile.readline()


### PR DESCRIPTION
Found and fix the issue in the "isRasterQml". No modification in line 97, the logic is the same.
Into qml for rasters there is not the "<rasterproperties>" tag.
I add "<rasterrenderer" tag actually present

I'm using Qgis 2.8.2 Wien